### PR TITLE
Fix #3 - Export user email addresses via the admin UI.

### DIFF
--- a/hldjango/code/accounts/static/accounts/js/export-emails.js
+++ b/hldjango/code/accounts/static/accounts/js/export-emails.js
@@ -1,0 +1,34 @@
+'use strict';
+{
+  window.addEventListener('load', () => {
+    // If the 'Export emails' button is clicked...
+    document.querySelector('.export-emails').addEventListener('click', (event) => {
+      event.preventDefault();
+
+      // If present, get the 'groups__id__exact' value from the URL.
+      const params = new URLSearchParams(window.location.search);
+      let groupID = '';
+      if (params.has('groups__id__exact')) {
+        groupID = params.get('groups__id__exact');
+      }
+
+      // Fetch the relevant user email addresses and display them in an alert.
+      fetch('/accounts/export-emails/' + groupID)
+        .then(response => {
+          if (response.ok) {
+            return response.json();
+          }
+          else {
+            throw new Error(`Response status: ${response.status}`);
+          }
+        })
+        .then(data => {
+          let emails = '';
+          for (const key in data) {
+            emails += "<" + data[key] + ">;";
+          }
+          alert(emails);
+        });
+    });
+  });
+}

--- a/hldjango/code/accounts/urls.py
+++ b/hldjango/code/accounts/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 
-from .views import ProfileView, ProfileEditView
+from .views import ProfileView, ProfileEditView, ExportEmailsView
 
 
 
@@ -9,5 +9,6 @@ urlpatterns = [
     path("profile/edit/<int:pk>", ProfileEditView.as_view(), name="accountEditProfile"),
     path("profile", ProfileView.as_view(), name="accountProfile"),
     path("profile/<int:pk>", ProfileView.as_view(), name="accountProfile"),
+    path("export-emails/", ExportEmailsView.as_view(), name="exportEmails"),
+    path("export-emails/<int:group_id>", ExportEmailsView.as_view(), name="exportEmails"),
 ]
-

--- a/hldjango/code/accounts/views.py
+++ b/hldjango/code/accounts/views.py
@@ -5,8 +5,10 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.shortcuts import HttpResponseRedirect
 from django.http import HttpResponse
 from django.shortcuts import resolve_url
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.contrib.auth.views import redirect_to_login
+from django.contrib.auth import get_user_model
+from django.views import View
 
 from lib.jr import jrdfuncs
 
@@ -71,7 +73,7 @@ class ProfileView(UserPassesTestMixin, DetailView):
 # helpers
 def getExplicitOrDefaultToLoggedInUser(view):
         # Here w'll retrieve the correct object to update
-        
+
         explicitPk = view.kwargs.get("pk", None)
         if (explicitPk is None):
              # defualt logged in user
@@ -81,7 +83,7 @@ def getExplicitOrDefaultToLoggedInUser(view):
                 return [None, errorResponse]
             # logged in user
             return [user, None]
-        
+
         # try to lookup user explicitly
         studiedUserPk = int(explicitPk)
         try:
@@ -104,3 +106,23 @@ def redirectToLoginFirst(view):
         resolved_login_url,
         view.get_redirect_field_name(),
     )
+
+
+class ExportEmailsView(UserPassesTestMixin, View):
+    """
+    Return a dictionary of user pks and email addresses, filtered by the given
+    group ID.
+    """
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def get(self, request, group_id = 0):
+        queryset = get_user_model().objects.all()
+        if group_id:
+            queryset = queryset.filter(groups__id__exact=group_id).distinct()
+        queryset = queryset.values('pk', 'email')
+        emails = {}
+        for item in queryset:
+            emails[item['pk']] = item['email']
+
+        return JsonResponse(emails)

--- a/hldjango/code/templates/admin/accounts/customuser/change_list.html
+++ b/hldjango/code/templates/admin/accounts/customuser/change_list.html
@@ -1,0 +1,12 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% static 'accounts/js/export-emails.js' %}" defer></script>
+{% endblock %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  <li><a href="#" class="export-emails">Export emails</a></li>
+{% endblock %}


### PR DESCRIPTION
### What it does

- Adds an 'Export emails' button at the top of user change list pages (both the default page and pages for users filtered by group)
<img width="1920" height="1080" alt="default" src="https://github.com/user-attachments/assets/f2c5dcb7-fc94-4e35-98f9-ca9b9b6980a5" />

- When the button is clicked, retrieves the relevant user emails and displays them in an alert. (This image shows email addresses for the user list filtered by GameAuthor).
<img width="1920" height="1080" alt="game-author-emails" src="https://github.com/user-attachments/assets/42e48259-4fb5-4975-8432-f8b0ebb561ad" />
